### PR TITLE
chore: check-yaml option, taskfile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,8 @@ repos:
             path/to/file3.json
           )$
       - id: check-yaml
+        args:
+          - --allow-multiple-documents
       - id: check-toml
       - id: check-xml
       - id: detect-private-key

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,6 +3,10 @@
 
 version: '3'
 
+vars:
+  # 一連の処理のエラーを捕捉
+  ON_ERROR: '/tmp/task_on_error_{{base .TASKFILE_DIR}}'
+
 tasks:
   default:
     cmd: task --list --sort alphanumeric
@@ -113,13 +117,8 @@ tasks:
         - TITLE
         - BRANCH
         - TARGET
-        - ON_ERROR
     cmds:
-      # - defer: {task: _git:on_error, vars: {ON_ERROR: "{{.ON_ERROR}}"}}
-      - defer:
-          task: _git:on_error
-          vars:
-            ON_ERROR: "{{.ON_ERROR}}"
+      - defer: _git:on_error
       - touch {{.ON_ERROR}}
       - ls -l {{.ON_ERROR}}
       - task: _git:auto


### PR DESCRIPTION
check-yaml で1つのyamlに複数ドキュメントを書くやつ（マニフェストみたいに）
があると引っ掛けちゃうのでオプションをつけることにした。

taskfile は defer に変数を渡す、ができなくなって久しいのでいい加減対応しようかなって。 グローバルに変数を置いておいて、タスクで値を変更すれば実行時にはそれが使われる。