### PR TITLE
fix: date コマンドをやめてテンプレートで処理する

### DIFF
--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -6,9 +6,8 @@ version: "3"
 vars:
   # 一連の処理のエラーを捕捉
   ON_ERROR: "/tmp/task_on_error_{{base .TASKFILE_DIR}}"
-  # date command の差異を吸収しやすくる
-  DATE_I:
-    sh: date "+%Y-%m-%d"
+  # date command の使用をやめて、Go の template を使うことで OS 依存を減らす
+  DATE_I: '{{ date "2006-01-02"  "now" }}'
 
 tasks:
   default:


### PR DESCRIPTION
- `date` コマンドを sh 等で呼び出して使うと OS 依存する
- BSD/GNU の差を吸収するのは手間がかかる（`date -I` は `date "+%Y-%m^%d"` で済むけど）
- Task にある Date functions （Go の Sprig）を使用することで実行環境の差異を吸収できる（Go が動作することは前提なので）