### PR TITLE
chore(cron): 記事を書くための issue の定期作成を再開

### DIFF
--- a/.github/workflows/this_week_article.yml
+++ b/.github/workflows/this_week_article.yml
@@ -1,8 +1,8 @@
 name: 今週も記事を書こう！
 
 on:
-  # schedule:
-  #   - cron: "0 15 * * SUN"
+  schedule:
+    - cron: "0 15 6,20 * *"
   workflow_dispatch:
 
 jobs:
@@ -16,7 +16,7 @@ jobs:
       - name: Date
         id: current
         env:
-          TZ: 'Asia/Tokyo'
+          TZ: "Asia/Tokyo"
         shell: bash
         run: |
           echo "date=$(date +%m/%d)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
- issue の定期作成を止めていたら普通に記事を書かなくなっていた
- 去年はがんばっていた
- https://zenn.dev/raki/scraps/1d9a9d0819c285
- というわけで定期実行を見直し
- 毎週書くのは大変なのはわかっているので、ニ週間に一回に頻度を下げる
- 月末月初は他にもやることがあるので、毎月7日と21日にしてみた（だいたいニ週間に一回）