### PR TITLE
chore(CI): 記事を書いたらスクラップに追加

### DIFF
--- a/.github/workflows/this_week_article.yml
+++ b/.github/workflows/this_week_article.yml
@@ -58,3 +58,4 @@ jobs:
             - この issue はネタのメモに使ってよい
             - 記事を書いたら issue number を入れて PR を出す
             - 自動で閉じても閉じなくてもよい、ことにする
+            - 記事を書いたら[scrap に追加しよう](https://zenn.dev/raki/scraps/1d9a9d0819c285)


### PR DESCRIPTION
- zenn の仕掛けの範疇で自分の書いた記事の検索や整理が簡単だったらいいのにな
- 何を書いて何を書いてないかぱっとわからなくなるのでちょっと前からスクラップに自前で整理している
- チケット側にリンクを書いておけば忘れないからね