### PR TITLE
fix: remove info from message.

### DIFF
--- a/articles/2025-10-13_git_commit_title.md
+++ b/articles/2025-10-13_git_commit_title.md
@@ -31,13 +31,13 @@ published: true
 - 内容が推測どおりのコミットはよいコミットのはずなので、なぜよいのかを考える
 - 内容が推測できないコミットタイトルはよくないコミットのはずなので、なぜよくないのかを考える
 
-:::message info
+:::message
 手直しするとしたらどのように書くかを考える
 :::
 
 ## conventional commit を使う
 
-@[card](https://www.conventionalcommits.org/)
+@[card](https://www.conventionalcommits.org/en/v1.0.0/)
 
 - [Conventional Commit の TYPE 選択フロー](https://zenn.dev/raki/articles/2025-07-25_conventional_commit)
 - 手癖でこの型で書けるようにする


### PR DESCRIPTION
- info 使えないかなって思ったけど使えないのでカット（zennのこういうとこダメだと思う）
- conventional commit のトップページはリダイレクトされて `/en/` みたいなタイトルになるので修正