### PR TITLE
feat: use dependabot for pre-commit update

### DIFF
--- a/.config/.pymarkdown.yaml
+++ b/.config/.pymarkdown.yaml
@@ -20,6 +20,7 @@ plugins:
     enabled: false
   no-bare-urls:
     enabled: false
+    # zenn で GitHub の特定行へのリンクはベアだけなので仕方なく
 extensions:
   front-matter:
     enabled: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "officel"
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,8 +1,6 @@
 name: pre-commit
 
 on:
-  schedule:
-    - cron: "0 15 1 * *"
   workflow_dispatch:
   pull_request:
 
@@ -19,20 +17,3 @@ jobs:
         with:
           python-version: "3.12"
       - uses: j178/prek-action@v1
-
-      - run: prek autoupdate
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          base: ${{ github.event.repository.default_branch }}
-          branch: update/prek-autoupdate
-          title: "build(deps): bump prek autoupdate"
-          commit-message: "build(deps): bump prek autoupdate"
-          body: |
-            Update versions of tools in prek
-            configs to latest version
-          add-paths: |
-            .pre-commit-config.yaml
-          assignees: ${{ github.actor }}
-          reviewers: ${{ github.actor }}


### PR DESCRIPTION
- https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/
- pre-commit が dependabot に対応したので自前の自動更新は止める
- reviwers まだ直してなかったのでついでに直す
- さらについでに前々から気になってた zenn で bare url を書く必要があるとこ対応した