### PR TITLE
feat: use betterleaks on prek, still use gitleaks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,11 @@ repos:
       - id: trailing-whitespace
       - id: check-merge-conflict
 
+  - repo: https://github.com/betterleaks/betterleaks
+    rev: 40d5cafea2045d16a217c1b70a69d6bba6b892ec  # frozen: v1.4.1
+    hooks:
+      - id: betterleaks
+
   - repo: https://github.com/gitleaks/gitleaks
     rev: 83d9cd684c87d95d656c1458ef04895a7f1cbd8e  # frozen: v8.30.1
     hooks:


### PR DESCRIPTION
- gitleaks がメンテモードに入ってるっぽいので betterleaks に移行
- 当面は両方入れておく（違いが見えてきたら gitleaks は外す）