### PR TITLE
chore: commit-message on dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
           - "*"
     cooldown:
       default-days: 7
+    commit-message:
+      prefix: "chore(ga):"
 
   - package-ecosystem: "pre-commit"
     directory: "/"
@@ -26,3 +28,5 @@ updates:
           - "*"
     cooldown:
       default-days: 7
+    commit-message:
+      prefix: "chore(pre-commit):"


### PR DESCRIPTION
- dependabot のPRタイトルは自動だから変えられないって前にAIが言ってたけど嘘だった
- 公式ドキュメントに設定が書いてあったのでちょっとテスト