### PR TITLE
feat: clear conventional-pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,3 @@ repos:
     rev: 91ab4bf57e58b32adf1a122681f6ebe164d081c8  # frozen: v4.4.0
     hooks:
       - id: conventional-pre-commit
-        stages: [commit-msg]
-        args:
-          [feat, fix, build, chore, ci, docs, perf, refactor, revert, style, test, blog]

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -71,8 +71,8 @@ tasks:
     cmds:
       - task: _git
         vars:
-          TITLE: "blog(raki): {{.DATE_I}} {{.CLI_ARGS}}"
-          BRANCH: "blog/raki/{{.DATE_I}}"
+          TITLE: "feat(raki): {{.DATE_I}} {{.CLI_ARGS}}"
+          BRANCH: "feat/blog/raki/{{.DATE_I}}"
           TARGET: "articles/ images/"
           # 一連の処理のエラーを捕捉
           ON_ERROR: /tmp/on_error_raki
@@ -104,8 +104,8 @@ tasks:
     cmds:
       - task: _git
         vars:
-          TITLE: "blog(terraform_jp): {{.DATE_I}} {{.CLI_ARGS}}"
-          BRANCH: "blog/terraform_jp/{{.DATE_I}}"
+          TITLE: "feat(terraform_jp): {{.DATE_I}} {{.CLI_ARGS}}"
+          BRANCH: "feat/blog/terraform_jp/{{.DATE_I}}"
           TARGET: "articles/ images/"
           # 一連の処理のエラーを捕捉
           ON_ERROR: /tmp/on_error_terraform_jp


### PR DESCRIPTION
- このリポジトリに関してのコミットは普段ほとんど task 任せにしている
- .pre-commit-config.yaml をできるだけクリーンにしようと思ったのでコミット部分を修正
- blog type はまぁまぁ見やすいんだけどブログ用のリポジトリだし feat で構わないかなって
- ryl の config についてはこちら https://github.com/owenlamont/ryl/issues/218