### PR TITLE
chore(ci): bump tools

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d  # v2.0.4
+      - uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d  # v2.0.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/betterleaks/betterleaks
-    rev: ac65f4739c352ab23dc2650a65be261016543599  # frozen: v1.5.0
+    rev: 28f08b4c8c4420a601f67ee9887c201697ff4568  # frozen: v1.6.1
     hooks:
       - id: betterleaks
 
@@ -35,7 +35,7 @@ repos:
       - id: zizmor
 
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: 479ff1e4e2ea17d1bf8ffef84e59a1a6942b55fc  # frozen: v0.2.20
+    rev: 77cb2353b60aecd74aa56db968b49ae0ff25144e  # frozen: v0.2.28
     hooks:
       - id: rumdl
         args: ["--fix"]


### PR DESCRIPTION
- dependabot 任せとどっちがいいか悩みどころ。。。
- こっちのほうが新しいの使える（cooldownしてない）けれども。。。